### PR TITLE
Fix iOS11 error about comparison between pointer and zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ cordova plugin add ../ImageDetectionCordovaPlugin
 ### IOS
 - The plugin aims to be used with iOS version >= 7.
 - **Important!** Go into src/ios folder and extract opencv2.framework from the zip file into the same folder.
+- Since iOS 10, `<key>NSCameraUsageDescription</key>` is required in the project Info.plist of any app that wants to use Camera. To add it, just open the project in XCode, go to the Info tab and add the `NSCameraUsageDescription` key with a string value that explain why your app need an access to the camera.
 
 ### Note
 In *config.xml* add Android and iOS target preference

--- a/src/ios/ImageDetectionPlugin.mm
+++ b/src/ios/ImageDetectionPlugin.mm
@@ -126,7 +126,7 @@ using namespace cv;
         NSNumber* argVal = [command.arguments objectAtIndex:0];
         NSString* msg;
 
-        if (argVal != nil && argVal > 0) {
+        if (argVal != nil && argVal > (void *) 0) {
             timeout = [argVal floatValue];
             ease_time = 0.5;
             timeout_started = [NSDate date];


### PR DESCRIPTION
As reported here : https://github.com/a31859/ImageDetectionDemoApp/issues/1 there is an issue with iOS11 and the plugin.

Full error was: `Ordered comparison between pointer and zero ('NSNumber *' and 'int')`
Casting the 0 to a `(void *)` fix the error.

**Edit:** My second commit is about an error that occur with iOS10+ if you don't add `NSCameraUsageDescription` in the Info.plist.